### PR TITLE
docs: add GitHub Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+# GitHub Copilot Instructions
+
+Use these guidelines when suggesting changes:
+
+- Write code in **TypeScript** and assume **React 19**.
+- Prefer **Tailwind CSS** and **daisyUI** components for styling.
+- Run `npm test` and `npm run lint` to verify changes before committing.
+- Format with Prettier and ensure ESLint passes.
+- Commit using the **conventional-changelog** format.
+


### PR DESCRIPTION
## Summary
- add repository-specific GitHub Copilot guidelines

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: Error while loading rule 'pnpm/json-enforce-catalog')*

------
https://chatgpt.com/codex/tasks/task_b_689be29dade083258fc805aff24bd5dc