### PR TITLE
feat: add seven segment clock display

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,9 +3,12 @@ import { Link } from '@tanstack/react-router'
 export default function Header() {
   return (
     <header className="p-2 flex gap-2 bg-white text-black justify-between">
-      <nav className="flex flex-row">
+      <nav className="flex flex-row gap-2">
         <div className="px-2 font-bold">
           <Link to="/">Home</Link>
+        </div>
+        <div className="px-2 font-bold">
+          <Link to="/clock">Clock</Link>
         </div>
       </nav>
     </header>

--- a/src/components/SevenSegmentDisplay.css
+++ b/src/components/SevenSegmentDisplay.css
@@ -1,0 +1,89 @@
+.seven-seg-display {
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 4px;
+  background-color: var(--ssd-background, #000);
+  color: var(--ssd-color, #ff0000);
+}
+
+.ssd-digit {
+  position: relative;
+  width: 24px;
+  height: 40px;
+}
+
+.ssd-segment {
+  position: absolute;
+  background-color: #330000;
+}
+
+.ssd-segment.on {
+  background-color: currentColor;
+}
+
+.ssd-segment.off {
+  background-color: #330000;
+}
+
+.ssd-segment.a {
+  top: 0;
+  left: 4px;
+  right: 4px;
+  height: 4px;
+}
+
+.ssd-segment.b {
+  top: 4px;
+  right: 0;
+  width: 4px;
+  height: 14px;
+}
+
+.ssd-segment.c {
+  bottom: 4px;
+  right: 0;
+  width: 4px;
+  height: 14px;
+}
+
+.ssd-segment.d {
+  bottom: 0;
+  left: 4px;
+  right: 4px;
+  height: 4px;
+}
+
+.ssd-segment.e {
+  bottom: 4px;
+  left: 0;
+  width: 4px;
+  height: 14px;
+}
+
+.ssd-segment.f {
+  top: 4px;
+  left: 0;
+  width: 4px;
+  height: 14px;
+}
+
+.ssd-segment.g {
+  top: 18px;
+  left: 4px;
+  right: 4px;
+  height: 4px;
+}
+
+.ssd-colon {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 4px 2px;
+}
+
+.ssd-colon .dot {
+  width: 4px;
+  height: 4px;
+  background-color: currentColor;
+}

--- a/src/components/SevenSegmentDisplay.test.tsx
+++ b/src/components/SevenSegmentDisplay.test.tsx
@@ -1,0 +1,26 @@
+/* @vitest-environment jsdom */
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import SevenSegmentDisplay from './SevenSegmentDisplay'
+
+describe('SevenSegmentDisplay', () => {
+  it('lights all segments for 8', () => {
+    const { getByTestId } = render(<SevenSegmentDisplay value="8" />)
+    ;['a', 'b', 'c', 'd', 'e', 'f', 'g'].forEach((seg) => {
+      const element = getByTestId(`d0-${seg}`)
+      expect(element.className).toContain('on')
+    })
+  })
+
+  it('lights only b and c for 1', () => {
+    const { getByTestId } = render(<SevenSegmentDisplay value="1" />)
+    ;['b', 'c'].forEach((seg) => {
+      const element = getByTestId(`d0-${seg}`)
+      expect(element.className).toContain('on')
+    })
+    ;['a', 'd', 'e', 'f', 'g'].forEach((seg) => {
+      const element = getByTestId(`d0-${seg}`)
+      expect(element.className).toContain('off')
+    })
+  })
+})

--- a/src/components/SevenSegmentDisplay.tsx
+++ b/src/components/SevenSegmentDisplay.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import './SevenSegmentDisplay.css'
+
+const digitToSegments: Partial<Record<string, string[]>> = {
+  '0': ['a', 'b', 'c', 'd', 'e', 'f'],
+  '1': ['b', 'c'],
+  '2': ['a', 'b', 'g', 'e', 'd'],
+  '3': ['a', 'b', 'g', 'c', 'd'],
+  '4': ['f', 'g', 'b', 'c'],
+  '5': ['a', 'f', 'g', 'c', 'd'],
+  '6': ['a', 'f', 'g', 'c', 'd', 'e'],
+  '7': ['a', 'b', 'c'],
+  '8': ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+  '9': ['a', 'b', 'c', 'd', 'f', 'g'],
+}
+
+interface SevenSegmentDisplayProps {
+  value: string
+  color?: string
+  background?: string
+}
+
+export default function SevenSegmentDisplay({
+  value,
+  color = '#ff0000',
+  background = '#000000',
+}: SevenSegmentDisplayProps) {
+  const chars = value.split('')
+
+  return (
+    <div className="seven-seg-display" style={{ color, backgroundColor: background }}>
+      {chars.map((ch, index) => {
+        if (ch === ':') {
+          return (
+            <div key={index} className="ssd-colon">
+              <div className="dot" />
+              <div className="dot" />
+            </div>
+          )
+        }
+
+        const onSegments = digitToSegments[ch] ?? []
+        return (
+          <div key={index} className="ssd-digit">
+            {['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((seg) => (
+              <div
+                key={seg}
+                data-testid={`d${index}-${seg}`}
+                className={`ssd-segment ${seg} ${onSegments.includes(seg) ? 'on' : 'off'}`}
+              />
+            ))}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+

--- a/src/routes/clock.tsx
+++ b/src/routes/clock.tsx
@@ -1,9 +1,26 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import SevenSegmentDisplay from '../components/SevenSegmentDisplay'
 
 export const Route = createFileRoute('/clock')({
   component: RouteComponent,
 })
 
 function RouteComponent() {
-  return <div>Hello "/clock"!</div>
+  const [now, setNow] = useState(new Date())
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const timeString = now.toLocaleTimeString(undefined, {
+    hour12: false,
+  })
+
+  return (
+    <div className="flex justify-center p-4">
+      <SevenSegmentDisplay value={timeString} />
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- add seven segment display component with optional color and background
- show current time using seven segment display on clock route
- add basic unit tests for segment mappings
- respect system locale for clock formatting

## Testing
- `npm test`
- `npm run lint` *(fails: pnpm-workspace.yaml not found for pnpm/json-enforce-catalog rule)*

------
https://chatgpt.com/codex/tasks/task_b_689be1f0b28883259c5871aebb62457c